### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Python Payer API
 ================
 
-[![Build Status](https://travis-ci.org/dessibelle/python-payer-api.svg?branch=master)](https://travis-ci.org/dessibelle/python-payer-api) [![Coverage Status](https://coveralls.io/repos/dessibelle/python-payer-api/badge.svg?branch=master)](https://coveralls.io/r/dessibelle/python-payer-api?branch=master) [![Latest Version](https://pypip.in/version/python-payer-api/badge.svg?style=flat)](https://pypi.python.org/pypi/python-payer-api/)
+[![Build Status](https://travis-ci.org/dessibelle/python-payer-api.svg?branch=master)](https://travis-ci.org/dessibelle/python-payer-api) [![Coverage Status](https://coveralls.io/repos/dessibelle/python-payer-api/badge.svg?branch=master)](https://coveralls.io/r/dessibelle/python-payer-api?branch=master) [![Latest Version](https://img.shields.io/pypi/v/python-payer-api.svg?style=flat)](https://pypi.python.org/pypi/python-payer-api/)
 
 Python package for interacting with the [Payer](http://payer.se) payments API.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20python-payer-api))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `python-payer-api`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.